### PR TITLE
Some minor improvements to block distribution tool

### DIFF
--- a/scripts/updateGadgets.ts
+++ b/scripts/updateGadgets.ts
@@ -60,7 +60,7 @@ async function update(target: 'prod' | 'dev', names: string[], definition: strin
     if (names[index] !== 'Gadgets-definition') {
       await bot.save(
         `MediaWiki:${names[index]}`,
-        "/* Automatically deployed from GitHub: https://github.com/Dianliang233/mcw-calc */\n" + file,
+        file,
         `Bot: Automatically deploy changes from Git`,
       )
       console.log(`Deployed ${names[index]}`)

--- a/scripts/updateGadgets.ts
+++ b/scripts/updateGadgets.ts
@@ -60,7 +60,7 @@ async function update(target: 'prod' | 'dev', names: string[], definition: strin
     if (names[index] !== 'Gadgets-definition') {
       await bot.save(
         `MediaWiki:${names[index]}`,
-        file,
+        "/* Automatically deployed from GitHub: https://github.com/Dianliang233/mcw-calc */\n" + file,
         `Bot: Automatically deploy changes from Git`,
       )
       console.log(`Deployed ${names[index]}`)

--- a/src/tools/blockDistribution/App.vue
+++ b/src/tools/blockDistribution/App.vue
@@ -329,5 +329,6 @@ ul.cdx-tabs__list {
 
 g.isolate {
   isolation: isolate;
+  pointer-events: none;
 }
 </style>

--- a/src/tools/blockDistribution/App.vue
+++ b/src/tools/blockDistribution/App.vue
@@ -319,6 +319,10 @@ function update() {
   background-color: transparent;
 }
 
+.cdx-tabs--quiet > .cdx-tabs__header .cdx-tabs__list__item--enabled [role="tab"] {
+  color: var(--content-text-color);
+}
+
 .cdx-tabs__next-scroller {
   display: none;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,9 @@ const config = (env, argv) => {
         __VUE_OPTIONS_API__: true,
         __VUE_PROD_DEVTOOLS__: false,
       }),
-      new webpack.BannerPlugin('Automatically generated, your edit will be overwritten'),
+      new webpack.BannerPlugin(
+        'Automatically deployed from GitHub: <https://github.com/Dianliang233/mcw-calc>, your edit will be overwritten',
+      ),
     ],
     performance: {
       hints: false,


### PR DESCRIPTION
Changes:
* fix color of dimensino tabs in dark mode
* Use default cursor when hovering over the graph

Also, I've tweaked the file sync script to add a comment that the gadget file is synced with GitHub. I accidentally edited one on the wiki because I didn't know.