### PR TITLE
Italicize title of block distribution tool

### DIFF
--- a/src/tools/blockDistribution/App.vue
+++ b/src/tools/blockDistribution/App.vue
@@ -213,7 +213,7 @@ function update() {
 }
 </script>
 <template>
-  <h4>Block distribution for {{ props.blockNames.join(', ') }} in Java Edition</h4>
+  <h4>Block distribution for {{ props.blockNames.join(', ') }} <i>in Java Edition</i></h4>
   <p style="font-size: 80%">
     Data from
     <a

--- a/src/tools/blockDistribution/App.vue
+++ b/src/tools/blockDistribution/App.vue
@@ -213,7 +213,7 @@ function update() {
 }
 </script>
 <template>
-  <h4>Block distribution for {{ props.blockNames.join(', ') }} <i>in Java Edition</i></h4>
+  <h4>Block distribution for {{ props.blockNames.join(', ') }} in <i>Java Edition</i></h4>
   <p style="font-size: 80%">
     Data from
     <a


### PR DESCRIPTION
As per [MCW:ITALICS](https://minecraft.wiki/w/MCW:ITALICS), the words "Java Edition" in the title of the block distribution tool should be italicized.